### PR TITLE
fix: add braces

### DIFF
--- a/exec.ps1
+++ b/exec.ps1
@@ -13,7 +13,7 @@ function Invoke-NativeApplication
     $ErrorActionPreference = "Continue"
     try
     {
-        Write-Verbose 'Executing native application with parameters: {0}' -f  [PSCustomObject] $ArgumentList
+        Write-Verbose ('Executing native application with parameters: {0}' -f [PSCustomObject] $ArgumentList)
         if (Test-CalledFromPrompt)
         {
             $wrapperScriptBlock = { & $ScriptBlock @ArgumentList }
@@ -30,8 +30,8 @@ function Invoke-NativeApplication
             }
         if ((-not $IgnoreExitCode) -and (Test-Path -Path Variable:LASTEXITCODE) -and ($AllowedExitCodes -notcontains $LASTEXITCODE))
         {
-            throw 'Native application with parameters {0} failed at {1} with exit code {2}' -f
-                ([PSCustomObject] $ArgumentList), (Get-PSCallStack -ErrorAction:SilentlyContinue)[1].Location, $LASTEXITCODE
+            throw ('Native application with parameters {0} failed at {1} with exit code {2}' -f
+                ([PSCustomObject] $ArgumentList), (Get-PSCallStack -ErrorAction:SilentlyContinue)[1].Location, $LASTEXITCODE)
         }
     }
     finally


### PR DESCRIPTION
The braces are required (pwsh 7.1.1) otherwise it will throw `A parameter cannot be found that matches parameter name 'f'.`